### PR TITLE
Fixes for non-directory projects

### DIFF
--- a/lib/pipe.coffee
+++ b/lib/pipe.coffee
@@ -22,7 +22,8 @@ module.exports =
       if history.length > 300
         history.shift()
 
-      commandString = "cd '#{atom.project.rootDirectory.path}' && #{commandString}"
+      if atom.project.rootDirectory?
+        commandString = "cd '#{atom.project.rootDirectory.path}' && #{commandString}"
       properties = { reversed: true, invalidate: 'never' }
 
       for range in editor.getSelectedBufferRanges()


### PR DESCRIPTION
Fixes the plugin for situations where Atom was opened to a file (`atom file.txt`), or without a project at all (`atom`)
