### PR TITLE
If nothing is selected, automatically select the entire buffer

### DIFF
--- a/lib/pipe.coffee
+++ b/lib/pipe.coffee
@@ -25,7 +25,13 @@ module.exports =
       commandString = "cd '#{atom.project.path}' && #{commandString}"
       properties = { reversed: true, invalidate: 'never' }
 
-      for range in editor.getSelectedBufferRanges()
+      selectedRanges = editor.getSelectedBufferRanges()
+
+      if selectedRanges.every((range) -> range.start == range.end)
+        editor.selectAll()
+        selectedRanges = editor.getSelectedBufferRanges()
+
+      for range in selectedRanges
         marker = editor.markBufferRange range, properties
         processRange marker, editor, commandString
 


### PR DESCRIPTION
Note that this may not be exactly what you want. It would eliminate the use case where you might just want to insert something at a certain point (such as just running `pwd` to insert the project directory). However, that doesn't really count as 'pipe-ing', so I think that this behavior makes sense.

I submitted 2 separate PRs for your convenience. Thanks.
