### PR TITLE
Use the `atom-text-editor` tag instead of the `editor` class.

### DIFF
--- a/keymaps/pipe.cson
+++ b/keymaps/pipe.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-text-editor':
+'atom-text-editor':
   'cmd-;': 'pipe:run'


### PR DESCRIPTION
This fixes the following deprecation warning:

  "In keymaps/pipe.cson: Use the atom-text-editor tag instead of
  the editor class."

Closes moshee/atom-pipe#15.