### PR TITLE
Use atom.commands.add instead of jQuery::on

### DIFF
--- a/lib/command-view.coffee
+++ b/lib/command-view.coffee
@@ -1,4 +1,5 @@
 {View, TextEditorView} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
 
 
 module.exports =
@@ -25,12 +26,18 @@ class CommandView extends View
     historyPos = history.length
     cur = ''
 
-    @on 'core:cancel core:close', =>
-      callback(null)
-      @detach()
-    @on 'core:confirm', =>
-      callback(@commandLine.getText())
-      @detach()
+    @disposables = new CompositeDisposable
+    @disposables.add atom.commands.add 'atom-workspace',
+      'core:cancel': =>
+        callback(null)
+        @detach()
+      'core:close': =>
+        callback(null)
+        @detach()
+      'core:confirm': =>
+        callback(@commandLine.getText())
+        @detach()
+
     @commandLine.on 'keydown', (e) =>
       if history.length is 0 then return
 
@@ -54,3 +61,6 @@ class CommandView extends View
 
     atom.workspace.addBottomPanel(item: this)
     @commandLine.focus()
+
+  detached: ->
+    @disposables.dispose()


### PR DESCRIPTION
Resolves the deprecation warning:

    Are you trying to listen for the 'core:cancel core:close' Atom
    command with jQuery::on? jQuery::trigger can no longer be used to
    listen for Atom commands. Please use atom.commands.add instead. See
    the docs at https://atom.io/docs/api/latest/CommandRegistry

See http://flight-manual.atom.io/upgrading-to-1-0-apis/sections/upgrading-your-package/#subscribing-to-commands

Fixes #18
Fixes #21